### PR TITLE
Add missing dependencies and remove an unused header

### DIFF
--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -5,7 +5,7 @@ idf_component_register(
     "dcd_esp32sx.c"
     "littlefs_api.c"
   PRIV_INCLUDE_DIRS "."
-  PRIV_REQUIRES "usb" "spi_flash")
+  PRIV_REQUIRES "usb" "spi_flash" "esp_partition")
 
 # canokey-core and esp-idf both have mbedtls
 set(MBEDTLS_TARGET_PREFIX "canokey-")

--- a/main/dcd_esp32sx.c
+++ b/main/dcd_esp32sx.c
@@ -32,7 +32,6 @@
 #include "freertos/xtensa_api.h"
 #include "esp_intr_alloc.h"
 #include "esp_log.h"
-#include "driver/gpio.h"
 #include "soc/dport_reg.h"
 #include "soc/gpio_sig_map.h"
 #include "soc/usb_periph.h"


### PR DESCRIPTION
In ESP-IDF v5.x, all the Partition APIs have been moved to the new component 'esp_partition'. So I added missing dependencies for this change.

And header file "driver/gpio.h" was not be used. So it was removed.